### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - llspy-slm
   - llspylibs >=0.1.3
   - llscd
+  - tifffolder
   - parse
   - pigz
 #  - lbzip2   # mac linux only


### PR DESCRIPTION
After creating a virtual environment from the .yml file within the llspy2 branch, the `tifffolder` module is not found. 

```
(base) C:\Users\Will\Documents\GitHub\LLSpy>conda activate llspydev

(llspydev) C:\Users\Will\Documents\GitHub\LLSpy>python -m llspy
Traceback (most recent call last):
  File "C:\Users\Will\Anaconda3\envs\llspydev\lib\runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "C:\Users\Will\Anaconda3\envs\llspydev\lib\runpy.py", line 142, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "C:\Users\Will\Anaconda3\envs\llspydev\lib\runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "C:\Users\Will\Documents\GitHub\LLSpy\llspy\__init__.py", line 1, in <module>
    from .llsdir import LLSdir
  File "C:\Users\Will\Documents\GitHub\LLSpy\llspy\llsdir.py", line 6, in <module>
    from tifffolder import TiffFolder
ModuleNotFoundError: No module named 'tifffolder'
```